### PR TITLE
Add dir target

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,10 @@
-# QDECR 0.7.0: OHBM
+# QDECR 0.7.1: OHBM (.1)
 
-Version 0.7.0 is the first version that is publically released. It is also the version that was presented at OHBM 2019 and was thus named "OHBM"
+Version 0.7.1 is the first version of QDECR after the public release. It will feature several improvements as well as additional arguments that extend (but not modify) the user experience.
 
 ## New functions and features
 
-
-
-
+* Added the argument `dir_target`, so that the target can be specified flexibly. 
 
 ## Major changes
 
@@ -16,4 +14,16 @@ Version 0.7.0 is the first version that is publically released. It is also the v
 
 ## Deprecated and defunct
 
-## documentation
+## Documentation
+
+# QDECR 0.7.0: OHBM
+
+Version 0.7.0 is the first version that is publically released. It is also the version that was presented at OHBM 2019 and was thus named "OHBM". As we do not have any formal news for versions before 0.7.0, we will keep it brief.
+
+## New functions and features
+
+* Creation of the QDECR package (before 0.7.0 it was a series of associated scripts)
+* Creation of the vw object and associated functions
+* Handling of imputed datasets (via imp2list)
+* Creation of all summary and plot functions
+* Creation of the `stack` concept

--- a/R/qdecr.R
+++ b/R/qdecr.R
@@ -43,6 +43,7 @@ qdecr <- function(id,
                   dir_subj = Sys.getenv("SUBJECTS_DIR"),
                   dir_fshome = Sys.getenv("FREESURFER_HOME"),
                   dir_tmp = dir_out,
+                  dir_target = dir_subj,
                   dir_out,
                   dir_out_tree = TRUE,
                   clean_up = TRUE,
@@ -103,7 +104,7 @@ qdecr <- function(id,
   # Assemble and check input arguments
   vw$input <- qdecr_check(id, md, margs, hemi, vertex, measure, model, target, project, dir_out_tree, clobber, fwhm, n_cores)
   vw$mask <- qdecr_check_mask(mask, mask_path)
-  vw$paths <- check_paths(vw, dir_tmp, dir_subj, dir_out, dir_fshome, mask_path)
+  vw$paths <- check_paths(vw, dir_tmp, dir_subj, dir_out, dir_target, dir_fshome, mask_path)
 
   # Check model
   vw$model <- qdecr_model(vw$input$model, vw$input$md, vw$input$id, vw$input$vertex, vw$input$margs, vw$paths$dir_tmp2)
@@ -168,7 +169,7 @@ qdecr <- function(id,
   # Estimate smoothness
   message2("Calculating smoothing for multiple testing correction.", 
            verbose = verbose)
-  vw$post$fwhm_est <- calc_fwhm(vw$paths$final_path, vw$paths$final_mask_path, vw$paths$est_fwhm_path, vw$input$hemi, vw$post$eres, mask = vw$mask, verbose = verbose)[,]
+  vw$post$fwhm_est <- calc_fwhm(vw$paths$final_path, vw$paths$final_mask_path, vw$paths$est_fwhm_path, vw$input$hemi, vw$post$eres, mask = vw$mask, path_target = vw$paths$path_target, verbose = verbose)[,]
   if(vw$post$fwhm_est > 30) {
     message2(paste0("Estimated smoothness is ", vw$post$fwhm_est, ", which is really high. Reduced to 30."), verbose = verbose)
     vw$post$fwhm_est <- 30

--- a/R/qdecr_check.R
+++ b/R/qdecr_check.R
@@ -86,16 +86,12 @@ check_dir_out <- function(dir_out, project, project2, dir_out_tree, clobber){
   dir_out
 }
 
-check_dir_subj <- function(dir_subj, target, md, id){
+check_dir_subj <- function(dir_subj, md, id){
   if(missing(dir_subj)) stop("No `dir_subj` argument provided. \n",
                              "Please provide a path to the directory that contains ",
                              "all the vertex input data.")
   if(!dir.exists(dir_subj))
     stop("The provided `dir_subj` does not seem to exist.")
-  if(!dir.exists(target)){
-    if(!dir.exists(file.path(dir_subj, target)))
-      stop("The provided `target` directory does not seem to exist.")
-  }
   idx <- md[[1]][[id]]
   f <- list.files(dir_subj)
   q <- !idx %in% f
@@ -110,6 +106,13 @@ check_dir_subj <- function(dir_subj, target, md, id){
     }
   }
   NULL
+}
+
+check_dir_target <- function(dir_target, target){
+  path_target <- file.path(dir_target, target)
+  if(!dir.exists(path_target)){
+    stop("The provided `target` directory does not seem to exist.")
+  }
 }
 
 check_fwhm <- function(fwhm){
@@ -140,8 +143,9 @@ check_id <- function(id, md){
   NULL
 }
 
-check_paths <- function(vw, dir_tmp, dir_subj, dir_out, dir_fshome, mask_path){
- check_dir_subj(dir_subj, vw$input$target, vw$input$md, vw$input$id)
+check_paths <- function(vw, dir_tmp, dir_subj, dir_out, dir_target, dir_fshome, mask_path){
+ check_dir_subj(dir_subj, vw$input$md, vw$input$id)
+ path_target <- check_dir_target(dir_target, vw$input$target)
  dir_out2 <- check_dir_out(dir_out, vw$input$project, vw$input$project2, vw$input$dir_out_tree, vw$input$clobber)
  if (is.null(dir_fshome) || dir_fshome == "") stop("dir_fshome is not specified. Please set the global variable FREESURFER_HOME.")
 
@@ -156,6 +160,8 @@ check_paths <- function(vw, dir_tmp, dir_subj, dir_out, dir_fshome, mask_path){
  paths[["dir_fshome"]] <- dir_fshome
  if(!identical(dir_out, dir_out2)) paths[["orig_dir_out"]] <- dir_out
  paths[["dir_out"]] <- dir_out2
+ paths[["dir_target"]] <- dir_target
+ paths[["path_target"]] <- path_target
  paths[["backing_mgh"]] <- backing_mgh
  paths[["mask_path"]] <- mask_path
  paths[["final_path"]] <- final_path

--- a/R/qdecr_check.R
+++ b/R/qdecr_check.R
@@ -113,6 +113,7 @@ check_dir_target <- function(dir_target, target){
   if(!dir.exists(path_target)){
     stop("The provided `target` directory does not seem to exist.")
   }
+  path_target
 }
 
 check_fwhm <- function(fwhm){

--- a/R/qdecr_describe.R
+++ b/R/qdecr_describe.R
@@ -35,6 +35,7 @@ qdecr_pre_describe <- function(vw, mask, verbose = TRUE) {
                       c("paths", "Subjects dir", vw$paths$dir_subj),
                       c("paths", "Freesurfer home dir", vw$paths$dir_fshome),
                       c("paths", "Temp dir", vw$paths$dir_tmp),
+                      c("paths", "Target path", vw$paths$path_target),
                       c("paths", "Output dir", vw$paths$dir_out),
                       c("paths", "Path to default mask", if(file.exists(vw$paths$mask_path)) vw$paths$mask_path else "Not found!")
                       )
@@ -87,9 +88,8 @@ qdecr_post_describe <- function(vw, verbose = TRUE) {
                      c("post", "Final mask path", vw$paths$final_mask_path),
                      c("post", "Final N vertices", sum(vw$post$final_mask)),
                      c("post", "Estimated fwhm", vw$post$fwhm_est),
-                     c("post", paste("Mean", vw$input$measure, "per vertex"), mean(vw$post$mgh_description$vertex_mean)),
+                     c("post", paste("Mean", vw$input$measure), mean(vw$post$mgh_description$vertex_mean)),
                      c("post", paste("SD", vw$input$measure, "per vertex"), mean(vw$post$mgh_description$vertex_sd)),
-                     c("post", paste("Mean", vw$input$measure, "per subject"), mean(vw$post$mgh_description$subject_mean)),
                      c("post", paste("SD", vw$input$measure, "per subject"), mean(vw$post$mgh_description$subject_sd))
                      )
   if (verbose) qdecr_print_describe(info, verbose = verbose)

--- a/R/qdecr_fastlm.R
+++ b/R/qdecr_fastlm.R
@@ -15,6 +15,7 @@
 #' @param dir_subj directory contain the surface-based maps (mgh files); defaults to SUBJECTS_DIR
 #' @param dir_fshome Freesurfer directory; defaults to FREESURFER_HOME
 #' @param dir_tmp directory to store the temporary big matrices; useful for shared memory; defaults to `dir_out`
+#' @param dir_target directory in which `target` is located (by default `dir_subj`)
 #' @param dir_out_tree if TRUE, creates a dir_out/project directory. If FALSE, all output is placed directory into dir_out
 #' @param clean_up_bm if TRUE, cleans all big matrices (.bk) that were generated in dir_tmp
 #' @param clean_up NOT IMPLEMENTED; will be used for setting cleaning of other files
@@ -41,6 +42,7 @@ qdecr_fastlm <- function(formula,
                          dir_subj = Sys.getenv("SUBJECTS_DIR"),
                          dir_fshome = Sys.getenv("FREESURFER_HOME"),
                          dir_tmp = dir_out,
+                         dir_target = dir_subj,
                          dir_out_tree = TRUE,
                          clean_up_bm = TRUE,
                          clean_up = TRUE,
@@ -84,6 +86,7 @@ vw <- qdecr(id = id,
             project = project,
             vertex = qqt,
             dir_tmp = dir_tmp,
+            dir_target = dir_target,
             dir_subj = dir_subj,
             dir_fshome = dir_fshome,
             dir_out_tree = dir_out_tree,

--- a/R/qdecr_post.R
+++ b/R/qdecr_post.R
@@ -2,7 +2,8 @@
 
 
 calc_fwhm <- function(final_path, final_mask_path, est_fwhm_path, hemi, eres, mask = NULL, path_target, verbose = FALSE) {
-  cmdStr <- paste("mris_fwhm", "--i", eres, "--hemi", hemi, "--subject", target, "--prune", "--cortex", "--dat", est_fwhm_path, "--out-mask", final_mask_path)
+  cmdStr <- paste("mris_fwhm", "--i", eres, "--hemi", hemi, "--subject", basename(path_target), "--sd", dirname(path_target), "--prune", "--cortex", "--dat", est_fwhm_path, "--out-mask", final_mask_path)
+  
   if (!is.null(mask)) paste(cmdStr, "--mask", mask)
   message2(verbose = verbose, cmdStr)
   system(cmdStr, ignore.stdout = !verbose)

--- a/R/qdecr_post.R
+++ b/R/qdecr_post.R
@@ -1,7 +1,7 @@
 
 
 
-calc_fwhm <- function(final_path, final_mask_path, est_fwhm_path, hemi, eres, mask = NULL, target = "fsaverage", verbose = FALSE) {
+calc_fwhm <- function(final_path, final_mask_path, est_fwhm_path, hemi, eres, mask = NULL, path_target, verbose = FALSE) {
   cmdStr <- paste("mris_fwhm", "--i", eres, "--hemi", hemi, "--subject", target, "--prune", "--cortex", "--dat", est_fwhm_path, "--out-mask", final_mask_path)
   if (!is.null(mask)) paste(cmdStr, "--mask", mask)
   message2(verbose = verbose, cmdStr)
@@ -20,8 +20,8 @@ runMriSurfCluster <- function(final_path, dir_fshome, hemi, pval, fwhm, mask_pat
     mczThr =  paste0("th", as.character(mczThr))
   }
 
-  oBaseName <- paste0(final_path, ".stack", stack, ".cache.", mczThr, '.', csdSign, ".sig")
-  if (fwhm < 10) fwhm <- paste0('0', fwhm)
+  oBaseName <- paste(final_path, paste0("stack", stack), "cache", mczThr, csdSign, "sig", sep = ".")
+  if (fwhm < 10) fwhm <- paste0("0", fwhm)
   csd <- file.path(dir_fshome, "average/mult-comp-cor/fsaverage", hemi, paste0("cortex/fwhm", fwhm), csdSign, mczThr, "mc-z.csd")
   cmdStr <- paste("mri_surfcluster",
                   "--in", pval,


### PR DESCRIPTION
This code adds the `dir_target` argument. It required some modifications to the call for `mris_fwhm` (I added the `--sd` flag for `dir_target`).