### PR TITLE
Modular check model

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: QDECR
 Type: Package
 Title: Vertex-wise statistical analysis
-Version: 0.7.0
+Version: 0.7.1.9000
 Authors@R: as.person(c(
     "Ryan Muetzel <r.muetzel@erasmusmc.nl> [aut, cre]",
     "Sander Lamballais <s.lamballaistessensohn@erasmusmc.nl> [aut]"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,10 @@
-# QDECR 0.7.0: OHBM
+# QDECR 0.7.1: OHBM (.1)
 
-Version 0.7.0 is the first version that is publically released. It is also the version that was presented at OHBM 2019 and was thus named "OHBM"
+Version 0.7.1 is the first version of QDECR after the public release. It will feature several improvements as well as additional arguments that extend (but not modify) the user experience.
 
 ## New functions and features
 
-
-
-
+* Added the argument `dir_target`, so that the target can be specified flexibly. 
 
 ## Major changes
 
@@ -16,4 +14,16 @@ Version 0.7.0 is the first version that is publically released. It is also the v
 
 ## Deprecated and defunct
 
-## documentation
+## Documentation
+
+# QDECR 0.7.0: OHBM
+
+Version 0.7.0 is the first version that is publically released. It is also the version that was presented at OHBM 2019 and was thus named "OHBM". As we do not have any formal news for versions before 0.7.0, we will keep it brief.
+
+## New functions and features
+
+* Creation of the QDECR package (before 0.7.0 it was a series of associated scripts)
+* Creation of the vw object and associated functions
+* Handling of imputed datasets (via imp2list)
+* Creation of all summary and plot functions
+* Creation of the `stack` concept

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,8 @@ Version 0.7.1 is the first version of QDECR after the public release. It will fe
 
 ## New functions and features
 
-* Added the argument `dir_target`, so that the target can be specified flexibly. 
+* Added the input argument `dir_target`, so that the target can be specified flexibly. 
+* Modularized `qdecr_model` and added the input argument `prep_fun`, so that users can choose and create their own prep functions.
 
 ## Major changes
 

--- a/R/qdecr.R
+++ b/R/qdecr.R
@@ -52,6 +52,7 @@ qdecr <- function(id,
                   verbose = TRUE,
                   debug = FALSE,
                   n_cores = 1,
+                  prep_fun = "prep_fastlm",
                   sander = FALSE
                   ){
   
@@ -102,12 +103,12 @@ qdecr <- function(id,
   md <- imp2list(data)
   
   # Assemble and check input arguments
-  vw$input <- qdecr_check(id, md, margs, hemi, vertex, measure, model, target, project, dir_out_tree, clobber, fwhm, n_cores)
+  vw$input <- qdecr_check(id, md, margs, hemi, vertex, measure, model, target, project, dir_out_tree, clobber, fwhm, n_cores, prep_fun)
   vw$mask <- qdecr_check_mask(mask, mask_path)
   vw$paths <- check_paths(vw, dir_tmp, dir_subj, dir_out, dir_target, dir_fshome, mask_path)
 
   # Check model
-  vw$model <- qdecr_model(vw$input$model, vw$input$md, vw$input$id, vw$input$vertex, vw$input$margs, vw$paths$dir_tmp2)
+  vw$model <- qdecr_model(vw$input$model, vw$input$prep_fun, vw$input$md, vw$input$id, vw$input$vertex, vw$input$margs, vw$paths$dir_tmp2)
   
   # Check backing
   qdecr_check_backing(c(vw$model$backing, vw$model$backing_to_remove, vw$paths$backing_mgh), clobber)

--- a/R/qdecr.R
+++ b/R/qdecr.R
@@ -43,6 +43,7 @@ qdecr <- function(id,
                   dir_subj = Sys.getenv("SUBJECTS_DIR"),
                   dir_fshome = Sys.getenv("FREESURFER_HOME"),
                   dir_tmp = dir_out,
+                  dir_target = dir_subj,
                   dir_out,
                   dir_out_tree = TRUE,
                   clean_up = TRUE,
@@ -103,7 +104,7 @@ qdecr <- function(id,
   # Assemble and check input arguments
   vw$input <- qdecr_check(id, md, margs, hemi, vertex, measure, model, target, project, dir_out_tree, clobber, fwhm, n_cores)
   vw$mask <- qdecr_check_mask(mask, mask_path)
-  vw$paths <- check_paths(vw, dir_tmp, dir_subj, dir_out, dir_fshome, mask_path)
+  vw$paths <- check_paths(vw, dir_tmp, dir_subj, dir_out, dir_target, dir_fshome, mask_path)
 
   # Check model
   vw$model <- qdecr_model(vw$input$model, vw$input$md, vw$input$id, vw$input$vertex, vw$input$margs, vw$paths$dir_tmp2)
@@ -168,7 +169,7 @@ qdecr <- function(id,
   # Estimate smoothness
   message2("Calculating smoothing for multiple testing correction.", 
            verbose = verbose)
-  vw$post$fwhm_est <- calc_fwhm(vw$paths$final_path, vw$paths$final_mask_path, vw$paths$est_fwhm_path, vw$input$hemi, vw$post$eres, mask = vw$mask, verbose = verbose)[,]
+  vw$post$fwhm_est <- calc_fwhm(vw$paths$final_path, vw$paths$final_mask_path, vw$paths$est_fwhm_path, vw$input$hemi, vw$post$eres, mask = vw$mask, path_target = vw$paths$path_target, verbose = verbose)[,]
   if(vw$post$fwhm_est > 30) {
     message2(paste0("Estimated smoothness is ", vw$post$fwhm_est, ", which is really high. Reduced to 30."), verbose = verbose)
     vw$post$fwhm_est <- 30

--- a/R/qdecr_check.R
+++ b/R/qdecr_check.R
@@ -86,16 +86,12 @@ check_dir_out <- function(dir_out, project, project2, dir_out_tree, clobber){
   dir_out
 }
 
-check_dir_subj <- function(dir_subj, target, md, id){
+check_dir_subj <- function(dir_subj, md, id){
   if(missing(dir_subj)) stop("No `dir_subj` argument provided. \n",
                              "Please provide a path to the directory that contains ",
                              "all the vertex input data.")
   if(!dir.exists(dir_subj))
     stop("The provided `dir_subj` does not seem to exist.")
-  if(!dir.exists(target)){
-    if(!dir.exists(file.path(dir_subj, target)))
-      stop("The provided `target` directory does not seem to exist.")
-  }
   idx <- md[[1]][[id]]
   f <- list.files(dir_subj)
   q <- !idx %in% f
@@ -110,6 +106,14 @@ check_dir_subj <- function(dir_subj, target, md, id){
     }
   }
   NULL
+}
+
+check_dir_target <- function(dir_target, target){
+  path_target <- file.path(dir_target, target)
+  if(!dir.exists(path_target)){
+    stop("The provided `target` directory does not seem to exist.")
+  }
+  path_target
 }
 
 check_fwhm <- function(fwhm){
@@ -140,8 +144,9 @@ check_id <- function(id, md){
   NULL
 }
 
-check_paths <- function(vw, dir_tmp, dir_subj, dir_out, dir_fshome, mask_path){
- check_dir_subj(dir_subj, vw$input$target, vw$input$md, vw$input$id)
+check_paths <- function(vw, dir_tmp, dir_subj, dir_out, dir_target, dir_fshome, mask_path){
+ check_dir_subj(dir_subj, vw$input$md, vw$input$id)
+ path_target <- check_dir_target(dir_target, vw$input$target)
  dir_out2 <- check_dir_out(dir_out, vw$input$project, vw$input$project2, vw$input$dir_out_tree, vw$input$clobber)
  if (is.null(dir_fshome) || dir_fshome == "") stop("dir_fshome is not specified. Please set the global variable FREESURFER_HOME.")
 
@@ -156,6 +161,8 @@ check_paths <- function(vw, dir_tmp, dir_subj, dir_out, dir_fshome, mask_path){
  paths[["dir_fshome"]] <- dir_fshome
  if(!identical(dir_out, dir_out2)) paths[["orig_dir_out"]] <- dir_out
  paths[["dir_out"]] <- dir_out2
+ paths[["dir_target"]] <- dir_target
+ paths[["path_target"]] <- path_target
  paths[["backing_mgh"]] <- backing_mgh
  paths[["mask_path"]] <- mask_path
  paths[["final_path"]] <- final_path

--- a/R/qdecr_check.R
+++ b/R/qdecr_check.R
@@ -14,7 +14,7 @@ qdecr_check_backing <- function(backing, clobber){
 }
 
 qdecr_check <- function(id, md, margs, hemi, vertex, measure, model, target,
-                        project, dir_out_tree, clobber, fwhm, n_cores){
+                        project, dir_out_tree, clobber, fwhm, n_cores, prep_fun){
 
   # verify that id is correct and exists within data
   check_id(id, md)
@@ -27,6 +27,9 @@ qdecr_check <- function(id, md, margs, hemi, vertex, measure, model, target,
 
   # Check whether the number of cores is correct
   check_cores(n_cores)
+  
+  # Check whether prep_fun exists
+  check_prep_fun(prep_fun)
 
   # Return all output arguments assembled
   input <- list()
@@ -45,6 +48,7 @@ qdecr_check <- function(id, md, margs, hemi, vertex, measure, model, target,
   input[["fwhm"]] <- fwhm
   input[["fwhmc"]] <- paste0("fwhm", fwhm)
   input[["n_cores"]] <- n_cores
+  input[["prep_fun"]] <- prep_fun
   input
 }
 
@@ -172,6 +176,11 @@ check_paths <- function(vw, dir_tmp, dir_subj, dir_out, dir_target, dir_fshome, 
  paths[] <- lapply(paths, sub, pattern = "//", replacement = "/", fixed = TRUE)
  paths[] <- lapply(paths, sub, pattern = "/$", replacement = "")
  paths
+}
+
+check_prep_fun <- function(prep_fun){
+  tryCatch(get2(prep_fun), error = function(e) stop("Provided `prep_fun` cannot be found."))
+  invisible(NULL)
 }
 
 check_vertex <- function(vertex, id, md){

--- a/R/qdecr_describe.R
+++ b/R/qdecr_describe.R
@@ -35,6 +35,7 @@ qdecr_pre_describe <- function(vw, mask, verbose = TRUE) {
                       c("paths", "Subjects dir", vw$paths$dir_subj),
                       c("paths", "Freesurfer home dir", vw$paths$dir_fshome),
                       c("paths", "Temp dir", vw$paths$dir_tmp),
+                      c("paths", "Target path", vw$paths$path_target),
                       c("paths", "Output dir", vw$paths$dir_out),
                       c("paths", "Path to default mask", if(file.exists(vw$paths$mask_path)) vw$paths$mask_path else "Not found!")
                       )
@@ -87,9 +88,8 @@ qdecr_post_describe <- function(vw, verbose = TRUE) {
                      c("post", "Final mask path", vw$paths$final_mask_path),
                      c("post", "Final N vertices", sum(vw$post$final_mask)),
                      c("post", "Estimated fwhm", vw$post$fwhm_est),
-                     c("post", paste("Mean", vw$input$measure, "per vertex"), mean(vw$post$mgh_description$vertex_mean)),
+                     c("post", paste("Mean", vw$input$measure), mean(vw$post$mgh_description$vertex_mean)),
                      c("post", paste("SD", vw$input$measure, "per vertex"), mean(vw$post$mgh_description$vertex_sd)),
-                     c("post", paste("Mean", vw$input$measure, "per subject"), mean(vw$post$mgh_description$subject_mean)),
                      c("post", paste("SD", vw$input$measure, "per subject"), mean(vw$post$mgh_description$subject_sd))
                      )
   if (verbose) qdecr_print_describe(info, verbose = verbose)

--- a/R/qdecr_fastlm.R
+++ b/R/qdecr_fastlm.R
@@ -24,6 +24,7 @@
 #' @param save if TRUE, saves the output to a .fst file
 #' @param save_data if TRUE, includes the raw data + design matrices in the .fst file
 #' @param debug NOT IMPLEMENTED; will output the maximal log to allow for easy debugging
+#' @param prep_fun Name of the function that needs to be called for the preparation step (do not touch unless you know what you are doing!)
 #' @return returns an object of classes "vw_fastlm" and "vw".
 #' @export
 
@@ -50,7 +51,8 @@ qdecr_fastlm <- function(formula,
                          verbose = TRUE,
                          save = TRUE,
                          save_data = TRUE,
-                         debug = FALSE){
+                         debug = FALSE,
+                         prep_fun = "prep_fastlm"){
 
 # Take apart the formula
 terms <- attr(terms(formula), "factors")
@@ -96,6 +98,7 @@ vw <- qdecr(id = id,
             verbose = verbose,
             debug = debug,
             n_cores = n_cores,
+            prep_fun = prep_fun,
             )
 
 vw$describe$call <- rbind(vw$describe$call, c("call", "qdecr_fastlm call", paste(trimws(deparse(match.call())), collapse = "")))

--- a/R/qdecr_fastlm.R
+++ b/R/qdecr_fastlm.R
@@ -15,6 +15,7 @@
 #' @param dir_subj directory contain the surface-based maps (mgh files); defaults to SUBJECTS_DIR
 #' @param dir_fshome Freesurfer directory; defaults to FREESURFER_HOME
 #' @param dir_tmp directory to store the temporary big matrices; useful for shared memory; defaults to `dir_out`
+#' @param dir_target directory in which `target` is located (by default `dir_subj`)
 #' @param dir_out_tree if TRUE, creates a dir_out/project directory. If FALSE, all output is placed directory into dir_out
 #' @param clean_up_bm if TRUE, cleans all big matrices (.bk) that were generated in dir_tmp
 #' @param clean_up NOT IMPLEMENTED; will be used for setting cleaning of other files
@@ -41,6 +42,7 @@ qdecr_fastlm <- function(formula,
                          dir_subj = Sys.getenv("SUBJECTS_DIR"),
                          dir_fshome = Sys.getenv("FREESURFER_HOME"),
                          dir_tmp = dir_out,
+                         dir_target = dir_subj,
                          dir_out_tree = TRUE,
                          clean_up_bm = TRUE,
                          clean_up = TRUE,
@@ -84,6 +86,7 @@ vw <- qdecr(id = id,
             project = project,
             vertex = qqt,
             dir_tmp = dir_tmp,
+            dir_target = dir_target,
             dir_subj = dir_subj,
             dir_fshome = dir_fshome,
             dir_out_tree = dir_out_tree,

--- a/R/qdecr_model.R
+++ b/R/qdecr_model.R
@@ -1,44 +1,22 @@
-
-qdecr_model <- function(model, md, id, vertex, margs, dir_tmp2){
-  
+qdecr_model <- function(model, prep_fun, md, id, vertex, margs, dir_tmp2) {
   prepvw <- list(model = model, data = md, id = id, 
-             vertex = vertex, margs = margs)
+                 vertex = vertex, margs = margs, path = dir_tmp2)
   class(prepvw) <- "prepvw"
+  do.call2(prep_fun, list(prepvw = prepvw))
+}
+
+qdecr_backing_path <- function(prepvw, to_keep, to_remove) {
+  prepvw$so <- c(to_keep, to_remove)
+  prepvw$backing <- paste0(prepvw$path, "_", prepvw$so[1:4], "_backend")
+  prepvw$backing_to_remove <- paste0(prepvw$path, "_", prepvw$so[5], "_backend")
+  return(prepvw)
+}
+
+prep_fastlm <- function(prepvw){
+  to_keep <- c("coef", "se", "t", "p")
+  to_remove <- "resid"
+  prepvw <- qdecr_backing_path(prepvw, to_keep, to_remove)
   
-  if (prepvw$model == "QDECR::megha") {
-    model_qdecr_megha(prepvw)
-  } else if (prepvw$model == "RcppEigen::fastLm") {
-      prepvw$so <- c("coef", "se", "t", "p", "resid")
-      prepvw$backing <- paste0(dir_tmp2, "_", prepvw$so[1:4], "_backend")
-      prepvw$backing_to_remove <- paste0(dir_tmp2, "_", prepvw$so[5], "_backend")
-      model_RcppEigen_fastLm(prepvw) 
-  } else if (prepvw$model == "stats::glm") {
-      model_stats_glm(prepvw)
-  } else if (prepvw$model == "stats::lm") {
-      model_stats_lm(prepvw)
-  } else if (prepvw$model == "survival::coxph") {
-      model_survival_coxph(prepvw)
-  } else if (prepvw$model == "default") {
-      prepvw$so <- c("coef", "se", "t", "p", "resid")
-      prepvw$backing <- paste0(dir_tmp2, "_", prepvw$so[1:4], "_backend")
-      prepvw$backing_to_remove <- paste0(dir_tmp2, "_", prepvw$so[5], "_backend")
-      model_default(prepvw)
-  }
-}
-
-model_default <- function(prepvw) {
-  prepvw$ff <- "vw_default"
-  prepvw$formula <- prepvw$margs$formula
-  vw <- prepvw
-  class(vw) <- c(vw$ff, "vw")
-  vw
-}
-
-model_qdecr_megha <- function(prepvw){
-  stop("`QDECR::megha` has not been implemented yet.")
-}
-
-model_RcppEigen_fastLm <- function(prepvw){
   mf <- prepvw$margs
   if (is.null(mf$formula)) 
     stop("No `formula` set in margs.")
@@ -63,15 +41,15 @@ model_RcppEigen_fastLm <- function(prepvw){
   mx_test[, prepvw$vertex] <- 999
   
   if (!identical(mx[[nn]], mx_test)) stop ("Somewhere in your formula you specified a special term related to your vertex measure", 
-    " (interaction, polynomial, AsIs, etc); `qdecr_fastlm` currently does not support this.")
-
+                                           " (interaction, polynomial, AsIs, etc); `qdecr_fastlm` currently does not support this.")
+  
   y <- model.response(mx[[nn]], "numeric")
   
   if (nrow(mx[[nn]]) != nr) stop("The data that you are putting into the regression has missings! \n",
                                  "QDECR can't handle that yet; we will fix this soon!")
   
   ys <- if(identical(unname(y), rep(999, nrow(mx[[nn]])))) "LHS" else "RHS"
-   
+  
   if (ys == "LHS") { 
     mx_test2 <- mx_test
     mx_test2b <- model.matrix(mx_test2, object = mt, contrasts)
@@ -92,78 +70,5 @@ model_RcppEigen_fastLm <- function(prepvw){
   }
   class(vw) <- c(vw$ff, "vw")
   vw
+  
 }
-
-model_stats_glm <- function(prepvw){
-  stop("`stats::glm` has not been implemented yet.")
-}
-
-model_stats_lm <- function(prepvw){
-  mf <- prepvw$margs
-  ret.x <- mf$x
-  ret.y <- mf$y
-  if (is.null(mf$drop.unused.levels)) 
-    mf$drop.unused.levels <- TRUE
-  if (is.null(mf$formula)) 
-    stop("No `formula` set in margs.")
-  iii <- c("formula", "data", "subset", "weights", "na.action", "offset")
-  mf[iii] <- mf[!sapply(mf, is.symbol)][iii]
-  mfz <- mf[match(c("formula", "data", "subset", "weights", "na.action", "offset"), names(mf), 0L)]
-  nr <- nrow(prepvw$data[[1]])
-  mx <- lapply(prepvw$data, function(x) {
-    mfz$data <- x
-    mfz$data[, prepvw$vertex] <- 999
-    do.call2("stats::model.frame", mfz)
-  })
-  nn <- length(prepvw$data)
-  if (mf$method == "model.frame")
-    stop("`margs$method` is equal to `model.frame` (for the lm call). Try `qr`.") else 
-      if (mf$method != "qr")
-    stop(gettextf("margs$method = '%s' is not supported in lm. Try 'qr'",
-                     method), domain = NA)
-  mt <- attr(mx[[nn]], "terms")
-  y <- model.response(mx[[nn]], "numeric")
-  ys <- if(identical(unname(y), rep(999, nr))) "LHS" else "RHS"
-  w <- as.vector(model.weights(mx[[nn]]))
-  if (!is.null(w) && !is.numeric(w)) 
-    stop("'margs$weights' must be a numeric vector (for the lm call)")
-  offset <- as.vector(model.offset(mf))
-  if (!is.null(offset)) {
-    if (length(offset) != NROW(y)) 
-      stop(gettextf("number of offsets is %d, should equal %d (number of observations) (in lm call)", 
-                    length(offset), NROW(y)), domain = NA)
-  }
-  if (is.empty.model(mt)) stop("The provided model (to lm) is empty. Check your data + formula.")
-  test <- model.matrix(mt, mx[[1]], contrasts) 
-  test2 <- model.matrix(mt, mx[[nn]], contrasts)
-  mm <- NULL
-  prepvw$ff <- "vw_lm_fit_slow"
-  if (prepvw$vertex %in% colnames(attr(mt, "factors")) || ys == "LHS"){
-    # mfz2 <- mfz
-    # mfz2$data <- prepvw$data[[1]]
-    # mfz2$data[, prepvw$vertex] <- mfz$data[, prepvw$vertex]
-    # mm2 <- do.call2("stats::model.frame", mfz2)
-    if(identical(test, test2)){
-      mm <- lapply(mx, model.matrix, object = mt, contrasts)
-      ff <- if (is.null(w)) "vw_lm_fit" else "vw.lm_wfit"
-      vw <- list(mm = mm, ff = ff, vertex = prepvw$vertex, ys = ys,
-                 y = y, w = w, offset = offset,
-                 singular.ok = prepvw$margs$singular.ok)
-    } else {
-      warning("Your formula for `lm` contains computed terms. \n", 
-              "We will rely on the slower implementation of our lm.")
-      vw <- prepvw
-    }
-  } else {
-    warning("Your formula for `lm` contains complicated terms. \n",
-            "We will rely on the slower implementation of our lm.")
-    vw <- prepvw
-  }
-  class(vw) <- c(vw$ff, "vw")
-  vw
-}
-
-model_survival_coxph <- function(prepvw){
-  stop("`survival::coxph` has not been implemented yet.")
-}
-

--- a/R/qdecr_post.R
+++ b/R/qdecr_post.R
@@ -1,8 +1,9 @@
 
 
 
-calc_fwhm <- function(final_path, final_mask_path, est_fwhm_path, hemi, eres, mask = NULL, target = "fsaverage", verbose = FALSE) {
-  cmdStr <- paste("mris_fwhm", "--i", eres, "--hemi", hemi, "--subject", target, "--prune", "--cortex", "--dat", est_fwhm_path, "--out-mask", final_mask_path)
+calc_fwhm <- function(final_path, final_mask_path, est_fwhm_path, hemi, eres, mask = NULL, path_target, verbose = FALSE) {
+  cmdStr <- paste("mris_fwhm", "--i", eres, "--hemi", hemi, "--subject", basename(path_target), "--sd", dirname(path_target), "--prune", "--cortex", "--dat", est_fwhm_path, "--out-mask", final_mask_path)
+  
   if (!is.null(mask)) paste(cmdStr, "--mask", mask)
   message2(verbose = verbose, cmdStr)
   system(cmdStr, ignore.stdout = !verbose)
@@ -20,8 +21,8 @@ runMriSurfCluster <- function(final_path, dir_fshome, hemi, pval, fwhm, mask_pat
     mczThr =  paste0("th", as.character(mczThr))
   }
 
-  oBaseName <- paste0(final_path, ".stack", stack, ".cache.", mczThr, '.', csdSign, ".sig")
-  if (fwhm < 10) fwhm <- paste0('0', fwhm)
+  oBaseName <- paste(final_path, paste0("stack", stack), "cache", mczThr, csdSign, "sig", sep = ".")
+  if (fwhm < 10) fwhm <- paste0("0", fwhm)
   csd <- file.path(dir_fshome, "average/mult-comp-cor/fsaverage", hemi, paste0("cortex/fwhm", fwhm), csdSign, mczThr, "mc-z.csd")
   cmdStr <- paste("mri_surfcluster",
                   "--in", pval,

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [![Project Status: Active - The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
 
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+
 # Information
 
 Please visit https://www.qdecr.com

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 > Vertex-wise analyses in R
 
-[![Project Status: Active - The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
-
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![Project Status: Active - The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active) [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
 # Information
 


### PR DESCRIPTION
This pull request concerns issue #3 
The code is modified to add an argument called `prep_fun` to `qdecr` (and by extension `qdecr_fastlm`). 

There is a `check_prep_fun` function that is called when checking the input. It checks whether `prep_fun` is actually a function.

The default function for both `qdecr` and `qdecr_fastlm` is set to `prep_fastlm`. 

Users can use their own prep functions as long as it aligns with the input of the subsequent analysis function, and their prep function is an exported object (i.e. `qdecr` can find it).