### PR TITLE
0.8.6: Fix 0-core problem in check_cores

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: QDECR
 Type: Package
 Title: Vertex-wise statistical analysis
-Version: 0.8.5
+Version: 0.8.6.9000
 Authors@R: as.person(c(
     "Ryan Muetzel <r.muetzel@erasmusmc.nl> [aut, cre]",
     "Sander Lamballais <s.lamballaistessensohn@erasmusmc.nl> [aut]"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# QDECR 0.8.6
+
+## Bug fixes
+
+* The specified number of cores is checked against `bigstatsr::nb_cores`. However, it seems that it returns 0 cores when only 1 core is found (given that it always omits 1core). We thus rewrote `check_cores` to use `parallel::detectCores`, and to make sure that it cannot return 0 cores.
+* Fixed the text in the error message of `check_cores`.
+
 # QDECR 0.8.5
 
 ## Bug fixes 

--- a/R/qdecr_check.R
+++ b/R/qdecr_check.R
@@ -58,9 +58,11 @@ qdecr_check <- function(id, md, margs, hemi, vertex, measure, model, target,
   input
 }
 
-check_cores <- function(n_cores){
-  rec_cores <- bigstatsr::nb_cores()
-  if (n_cores > rec_cores) stop("You specified `", n_cores, "` to be too high. Recommended is ", rec_cores)
+check_cores <- function(n_cores) {
+  if (n_cores < 1) stop("You specified `n_cores` to be smaller than 1. Please choose a number that is 1 or higher.")
+  rec_cores <- parallel::detectCores() - 1
+  if (rec_cores == 0) rec_cores <- 1
+  if (n_cores > rec_cores) stop("You specified `n_cores` to be too high (", n_cores, "). Recommended is ", rec_cores)
   NULL
 }
 


### PR DESCRIPTION
* In `QDECR:::check_cores`, swapped out `bigstatsr::nb_cores` for `parallel::detectCores`. 
* Made sure that if the returned number of cores is 0, then it will be set to 1.
* Fixed error message in `check_cores`.