### PR TITLE
0.8.6: unsmoothed q-cached files now work

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,9 @@
 
 ## Bug fixes
 
-* The specified number of cores is checked against `bigstatsr::nb_cores`. However, it seems that it returns 0 cores when only 1 core is found (given that it always omits 1core). We thus rewrote `check_cores` to use `parallel::detectCores`, and to make sure that it cannot return 0 cores.
-* Fixed the text in the error message of `check_cores`.
+* The specified number of cores is checked against `bigstatsr::nb_cores` (inside `QDECR:::check_cores`). However, it seems that it returns 0 cores when only 1 core is found (given that it always omits 1core). We thus rewrote `check_cores` to use `parallel::detectCores`, and to make sure that it cannot return 0 cores.
+* Fixed the text in the error message of `QDECR:::check_cores`.
+* Unsmoothed q-cached surface files can now be analyzed. Normally, QDECR would look for files containing `fwhmX`, where X is the FWHM in mm. However, unsmoothed files do not contain this part. The code was rewritten to check if fwhm == 0, and in those cases it will not insert that into the file names. This was fixed by setting `fwhmc` to "" in `QDECR:::qdecr_check`.
 
 # QDECR 0.8.5
 

--- a/R/qdecr_check.R
+++ b/R/qdecr_check.R
@@ -52,7 +52,7 @@ qdecr_check <- function(id, md, margs, hemi, vertex, measure, model, target,
   input[["file_out_tree"]] <- file_out_tree
   input[["clobber"]] <- clobber
   input[["fwhm"]] <- fwhm
-  input[["fwhmc"]] <- paste0("fwhm", fwhm)
+  input[["fwhmc"]] <- if (fwhm > 0) paste0("fwhm", fwhm) else ""
   input[["n_cores"]] <- n_cores
   input[["prep_fun"]] <- prep_fun
   input


### PR DESCRIPTION
* Unsmoothed q-cached files should now be useable, as I changed `QDECR:::qdecr_check` to set `fwhmc` to "" when fwhm == 0.