### PR TITLE
0.8.6: efficient vertex-wise lm rewrite

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
 * Fixed the text in the error message of `QDECR:::check_cores`.
 * Unsmoothed q-cached surface files can now be analyzed. Normally, QDECR would look for files containing `fwhmX`, where X is the FWHM in mm. However, unsmoothed files do not contain this part. The code was rewritten to check if fwhm == 0, and in those cases it will not insert that into the file names. This was fixed by setting `fwhmc` to "" in `QDECR:::qdecr_check`.
 
+## Minor tweaks
+* Tweaked the vertex-wise analysis code (`QDECR:::analysis_chunkedlm`) to be faster and be more memory efficient (`se` is now calculated without the intermediate storage of `s2`).
+
 # QDECR 0.8.5
 
 ## Bug fixes 

--- a/R/qdecr_analysis.R
+++ b/R/qdecr_analysis.R
@@ -56,8 +56,7 @@ analysis_chunkedlm <- function(vw, chunk) {
     res <- lapply(1:m, function(z) Y - X[[z]] %*% bhat[[z]])
     
     # get se
-    s2 <- lapply(res, function(z) colSums(z^2 / df))
-    se <- lapply(1:m, function(z) do.call("cbind", lapply(s2[[z]], function(q) sqrt(diag(q * XTX[[z]])))))
+    se <- lapply(1:m, function(z) sqrt(tcrossprod(diag(XTX[[z]]), colSums(res^2)[[z]]) / df))
     
     # pool and get t
     out <- quick_pool2(bhat, se = se)


### PR DESCRIPTION
* Efficiency rewrite of `QDECR:::analysis_chunkedlm`; removed the intermediate `s2` step.