### PR TITLE
0.9.0 check for parallelism layers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,13 +11,14 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 Imports:
-    bigstatsr (>= 0.6.2),
+    bigstatsr (>= 1.5.1),
     doParallel (>= 1.0.14),
     foreach (>= 1.4.4),
     Matrix (>= 1.2.12),
     methods,
     parallel,
     RcppEigen (>= 0.3.3.4.0),
+    RhpcBLASctl (>= 0.21.247.1),
     stats (>= 3.4.3)
 Suggests:
     magick (>= 2.0),

--- a/R/qdecr_check.R
+++ b/R/qdecr_check.R
@@ -1,3 +1,12 @@
+## COPIED FROM bigparallelr:::default_nproc_blas
+default_nproc_blas <- function() {
+
+  cl <- parallel::makePSOCKcluster(1)
+  on.exit(parallel::stopCluster(cl), add = TRUE)
+
+  parallel::clusterEvalQ(cl, RhpcBLASctl::blas_get_num_procs())[[1]]
+}
+
 qdecr_check_backing <- function(backing, clobber){
   for (n in backing){
     n <- paste0(n, ".bk")
@@ -63,6 +72,7 @@ check_cores <- function(n_cores) {
   rec_cores <- parallel::detectCores() - 1
   if (rec_cores == 0) rec_cores <- 1
   if (n_cores > rec_cores) stop("You specified `n_cores` to be too high (", n_cores, "). Recommended is ", rec_cores)
+  if (n_cores > 1 && default_nproc_blas() > 1) stop("`n_cores` > 1, but there already seems to be a parallel BLAS library present. Either set `n_cores` to 1, or set the BLAS library to 1.")
   NULL
 }
 


### PR DESCRIPTION
Imeplemented a check to see whether `n_cores` > 1 and simultaneously a parallel BLAS library is already running multithreaded. This was done inside `QDECR:::check_cores`.